### PR TITLE
fix(alacritty): uncomment italic

### DIFF
--- a/.config/alacritty/alacritty.yml
+++ b/.config/alacritty/alacritty.yml
@@ -129,7 +129,7 @@ font:
     style: Bold
 
   # Italic font face
-  #italic:
+  italic:
     # Font family
     #
     # If the italic family is not specified, it will fall back to the


### PR DESCRIPTION
## Alacritty

The key `italic` of the `font` section in the config was commented out (maybe by mistake)