### PR TITLE
fix extra space in yabai plugin

### DIFF
--- a/.config/sketchybar/plugins/yabai.sh
+++ b/.config/sketchybar/plugins/yabai.sh
@@ -55,8 +55,8 @@ windows_on_spaces () {
         while IFS= read -r app; do
           icon_strip+=" $($CONFIG_DIR/plugins/icon_map.sh "$app")"
         done <<< "$apps"
+        args+=(--set space.$space label="$icon_strip" label.drawing=on)
       fi
-      args+=(--set space.$space label="$icon_strip" label.drawing=on)
     done
   done <<< "$CURRENT_SPACES"
 


### PR DESCRIPTION
The original dotfile of sketchybar will create extra space even if there is no window in a space. Like this:
<img width="356" alt="image" src="https://github.com/FelixKratz/dotfiles/assets/27361279/ec4e3d79-ee30-4e76-ba92-7d40d633bf97">

I believe this is a bug, since no window means no need rendering the label. I fixed this bug, and now the bar looks like this:
<img width="337" alt="image" src="https://github.com/FelixKratz/dotfiles/assets/27361279/d8c8bdb5-d080-4f3c-9386-d41399289388">

I think it's much better. But if this is meant to be designed in the original way, just ignore my pull request.

Much appreciate for the great job! 