### PR TITLE
Fix Battery Icon in Bracket in zen mode

### DIFF
--- a/.config/sketchybar/items/volume.sh
+++ b/.config/sketchybar/items/volume.sh
@@ -39,5 +39,5 @@ sketchybar --add slider volume right            \
            --add item volume_icon right         \
            --set volume_icon "${volume_icon[@]}"
 
-sketchybar --add bracket status brew github.bell volume_icon \
+sketchybar --add bracket status brew github.bell volume_icon battery \
            --set status "${status_bracket[@]}"


### PR DESCRIPTION
Battery Icon is outside the Bracket in Zen mode. This puts it inside the bracket.

The padding left is a little small, but for me this is fine (didn't want to change the padding since in non-zen mode it looks fine :D) and also for me this is no problem :)

Since you have the battery icon inside the bracket in non zen mode, i thought this is a bug and you would like to have it inside the bracket in zen mode aswell