### PR TITLE
Added a VPN check

### DIFF
--- a/.config/sketchybar/icons.lua
+++ b/.config/sketchybar/icons.lua
@@ -34,6 +34,7 @@ local icons = {
       connected = "􀙇",
       disconnected = "􀙈",
       router = "􁓤",
+      vpn = "􀒲",
     },
     media = {
       back = "􀊊",

--- a/.config/sketchybar/items/widgets/wifi.lua
+++ b/.config/sketchybar/items/widgets/wifi.lua
@@ -183,6 +183,17 @@ wifi:subscribe({"wifi_change", "system_woke"}, function(env)
       },
     })
   end)
+  sbar.exec("scutil --nc list | grep 'Connected'", function(result)
+    local connected = not (result == "")
+    if connected then
+      wifi:set({
+        icon = {
+          string = icons.wifi.vpn,
+          color = colors.white,
+        },
+      })
+    end
+  end)
 end)
 
 local function hide_details()


### PR DESCRIPTION
Hi Felix,

I really appreciate your work on SketchyBar, Svim, and the dotfiles. I use them extensively and they make my life much easier.

I've made two changes to your SketchyBar dotfiles that I think you'll find useful.

Feature:
Added a check to items/widgets/wifi.lua to see if the user is connected to a VPN.
If the user is connected to a VPN, the wifi icon in the menubar changes to a lock.
I think this is a useful feature for users who frequently use a VPN, like myself. It provides a quick and easy way to see if you're connected to a VPN.

I've tested this change on my own machine and it seems to work well. Please let me know if you have any questions or concerns.

Thank you!
Your work on all your repositories is amazing and very much appreciated!