### PR TITLE
MacOS Sequoia fixes to single-line command for installing sketchybar and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ One-line install for sketchybar config (requires brew to be installed):
 ```bash
 curl -L https://raw.githubusercontent.com/FelixKratz/dotfiles/master/install_sketchybar.sh | sh
 ```
+On MacOS Sequoia, due to Apple's recently updated Security protocols, you'll need to run with ```sudo```.
+```bash
+sudo curl -L https://raw.githubusercontent.com/FelixKratz/dotfiles/master/install_sketchybar.sh | sh
+```
 
 Previous Setups
 ----------------------


### PR DESCRIPTION
MacOS Sequoia updated their wecurity protocols so several of the folders accessed by the one-line install command are no longer editable by terminal. Running it with sudo fixes this. Added to README to help any other Sequoia users.