### PR TITLE
hide battery popup when mouse exits

### DIFF
--- a/.config/sketchybar/items/widgets/battery.lua
+++ b/.config/sketchybar/items/widgets/battery.lua
@@ -90,6 +90,10 @@ battery:subscribe("mouse.clicked", function(env)
   end
 end)
 
+battery:subscribe("mouse.exited.global", function()
+  battery:set( { popup = { drawing = "off" } })
+end)
+
 sbar.add("bracket", "widgets.battery.bracket", { battery.name }, {
   background = { color = colors.bg1 }
 })


### PR DESCRIPTION
Automatically hide the battery widget popup on the `mouse.exited.global` event, matching the behavior of the other widget popups, such as wifi.